### PR TITLE
allow args compatible with browserify and smokestack

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,13 +6,8 @@ const values = require('pull-stream/sources/values')
 const map = require('pull-stream/throughs/map')
 const asyncMap = require('pull-stream/throughs/async-map')
 const onEnd = require('pull-stream/sinks/on-end')
-const window = require('global/window')
 var Gherkin = require('gherkin')
 
-// Grrrrrrrrrrrrr
-if (window && window.Gherkin) {
-  Gherkin = window.Gherkin
-}
 module.exports = cukeTap
 
 // Gherkin tap producing test harness

--- a/index.js
+++ b/index.js
@@ -6,9 +6,13 @@ const values = require('pull-stream/sources/values')
 const map = require('pull-stream/throughs/map')
 const asyncMap = require('pull-stream/throughs/async-map')
 const onEnd = require('pull-stream/sinks/on-end')
-const glob = require('pull-glob')
-const Gherkin = require('gherkin')
+const window = require('global/window')
+var Gherkin = require('gherkin')
 
+// Grrrrrrrrrrrrr
+if (window && window.Gherkin) {
+  Gherkin = window.Gherkin
+}
 module.exports = cukeTap
 
 // Gherkin tap producing test harness
@@ -33,11 +37,12 @@ function isArrayOfArrays (thing) {
 }
 
 function featureSource (features) {
-  if (isArrayOfArrays(features)) return values(features)
-  else {
+  if (isArrayOfArrays(features)) {
+    return values(features)
+  } else {
     return pull(
       typeof features === 'string'
-        ? glob(features)
+        ? require('pull-glob')(features)
         : values(features)
       ,
       readFiles()
@@ -48,7 +53,6 @@ function featureSource (features) {
 function readFiles () {
   return asyncMap(function (featurePath, cb) {
     fs.readFile(featurePath, 'utf8', function (err, featureSource) {
-      console.log('FEATURE SOURCE', featureSource)
       if (err) cb(err)
       else cb(null, [featurePath, featureSource])
     })

--- a/index.js
+++ b/index.js
@@ -16,13 +16,8 @@ module.exports = cukeTap
 function cukeTap (options, cb) {
   const steps = options.steps
   const features = options.features
-
   pull(
-    typeof features === 'string'
-      ? glob(features)
-      : values(features)
-    ,
-    readFiles(),
+    featureSource(features),
     parseGherkin(),
     compilePickles(),
     runTests(steps),
@@ -30,9 +25,30 @@ function cukeTap (options, cb) {
   )
 }
 
+function isArrayOfArrays (thing) {
+  if (Array.isArray(thing)) {
+    return Array.isArray(thing[0])
+  }
+  return false
+}
+
+function featureSource (features) {
+  if (isArrayOfArrays(features)) return values(features)
+  else {
+    return pull(
+      typeof features === 'string'
+        ? glob(features)
+        : values(features)
+      ,
+      readFiles()
+    )
+  }
+}
+
 function readFiles () {
   return asyncMap(function (featurePath, cb) {
     fs.readFile(featurePath, 'utf8', function (err, featureSource) {
+      console.log('FEATURE SOURCE', featureSource)
       if (err) cb(err)
       else cb(null, [featurePath, featureSource])
     })

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "gherkin": "^4.0.0",
-    "global": "^4.3.0",
+    "gherkin": "github:cucumber/gherkin-javascript",
     "pull-glob": "^1.0.6",
     "pull-stream": "^3.4.3",
     "tape": "^4.6.0"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "gherkin": "^4.0.0",
+    "global": "^4.3.0",
     "pull-glob": "^1.0.6",
     "pull-stream": "^3.4.3",
     "tape": "^4.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cuke-tap",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Gherkin tap producing test harness",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
previously i've been using  `jsdom` to do browser testing, but fortunately this doesn't support MutationObserver, which is necessary if your app uses [`on-load`](https://github.com/shama/on-load) or want to test with [`pull-dom-mutants`](https://github.com/pietgeursen/pull-dom-mutants).

this change, thanks to @pietgeursen, adds another way to pass arguments into `cuke-tap`, in a way that's compatible with being bundled with `browserify` and run with [`smokestack`](https://github.com/hughsk/smokestack). basically, `gherkin` needs the feature file content and the feature file path, so the new argument signature is passing in an array of arrays with this information.

after we add this new argument signature then it's possible to include a special browserify transform that does this automatically using [`static-module`](https://github.com/substack/static-module). 
